### PR TITLE
Add BYPASS_PERIMETER_FUNCTION setting

### DIFF
--- a/perimeter/middleware.py
+++ b/perimeter/middleware.py
@@ -9,17 +9,11 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 
 from perimeter.models import AccessToken, EmptyToken
-from perimeter.settings import PERIMETER_SESSION_KEY, PERIMETER_ENABLED
-
-
-def bypass_perimeter(request):
-    """Return True if the perimeter can be ignored for the request url.
-
-    Certain views bypass the gateway as they are themselves login pages -
-    specifically the admin site login and the perimeter login itself.
-
-    """
-    return request.path == reverse('perimeter:gateway')
+from perimeter.settings import (
+    PERIMETER_SESSION_KEY,
+    PERIMETER_ENABLED,
+    PERIMETER_BYPASS_FUNCTION as bypass_perimeter
+)
 
 
 def get_request_token(request):

--- a/perimeter/settings.py
+++ b/perimeter/settings.py
@@ -3,6 +3,7 @@
 from os import environ
 
 from django.conf import settings
+from django.core.urlresolvers import reverse
 
 CAST_AS_BOOL = lambda x: x in (True, 'true', 'True')
 CAST_AS_INT = lambda x: int(x)
@@ -35,3 +36,10 @@ PERIMETER_ENABLED = get_setting('PERIMETER_ENABLED', False, cast_func=CAST_AS_BO
 PERIMETER_SESSION_KEY = get_setting('PERIMETER_SESSION_KEY', "perimeter")
 # default expiry, in days, of a token
 PERIMETER_DEFAULT_EXPIRY = get_setting('PERIMETER_DEFAULT_EXPIRY', 7, cast_func=CAST_AS_INT)
+# function used to bypass the perimter - must be function that takes request as only arg
+# NB we don't use get_setting here as it makes no sense - you can put a function into an env var
+PERIMETER_BYPASS_FUNCTION = getattr(
+    settings, 'PERIMETER_BYPASS_FUNCTION',
+    # default function is to restrict everything except the gateway page itself
+    lambda r: r.path == reverse('perimeter:gateway')
+)

--- a/perimeter/tests/test_middleware.py
+++ b/perimeter/tests/test_middleware.py
@@ -36,7 +36,7 @@ class PerimeterMiddlewareTests(TestCase):
         self.assertEqual(resolver.url_name, 'gateway')
         self.assertEqual(resolver.namespace, 'perimeter')
 
-    def test_bypass_perimeter(self):
+    def test_bypass_perimeter_default(self):
         """Perimeter login urls excluded."""
         request = self.factory.get('/')
         self.assertFalse(bypass_perimeter(request))
@@ -51,13 +51,6 @@ class PerimeterMiddlewareTests(TestCase):
     def test_get_request_token_empty(self):
         token = get_request_token(self.request)
         self.assertTrue(type(token) == EmptyToken)
-
-    # def test_disabled(self):
-    #     """Check the PERIMETER_ENABLED setting is honoured."""
-    #     self.assertRaises(
-    #         MiddlewareNotUsed,
-    #         PerimeterAccessMiddleware  # runs __init__()
-    #     )
 
     def test_missing_session(self):
         """Missing request.session should raise AssertionError."""


### PR DESCRIPTION
Enables use of a function to allow requests to circumvent the perimeter.

Defaults to the allowing the perimeter gateway url only:

``` python
PERIMETER_BYPASS_FUNCTION = getattr(
    settings, 'PERIMETER_BYPASS_FUNCTION',
    # default function is to restrict everything except the gateway page itself
    lambda r: r.path == reverse('perimeter:gateway')
)
```

If you want to override this to allow other urls, or perhaps some request attributes, then add it as a django setting.
