### PR TITLE
Fix `next` query param encoding and resolution.

### DIFF
--- a/perimeter/middleware.py
+++ b/perimeter/middleware.py
@@ -3,6 +3,8 @@
 Middleware component of Perimeter app - checks all incoming requests for a
 valid token. See Perimeter docs for more details.
 """
+import urllib
+
 from django.conf import settings
 from django.core.exceptions import MiddlewareNotUsed, PermissionDenied
 from django.core.urlresolvers import reverse
@@ -68,7 +70,7 @@ class PerimeterAccessMiddleware(object):
             return None
 
         # redirect to the gateway for validation,
+        qstring = urllib.urlencode({'next': request.get_full_path()})
         return HttpResponseRedirect(
-            reverse('perimeter:gateway') +
-            '?next=%s' % request.path
+            reverse('perimeter:gateway') + '?' + qstring
         )

--- a/perimeter/views.py
+++ b/perimeter/views.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 # Perimeter app views
+import urllib
+
 from django.core.urlresolvers import reverse, resolve, Resolver404
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
@@ -17,8 +19,14 @@ def resolve_return_url(return_url):
     know exists - perimeter:gateway
 
     """
+    path = None
+    if return_url:
+        return_url = urllib.unquote(return_url)
+        # Path with a query string will not resolve, so we strip it for the check.
+        path = return_url.split("?")[0]
+
     try:
-        url = resolve(return_url)
+        resolve(path)
         return return_url
     except Resolver404:
         return reverse('perimeter:gateway')


### PR DESCRIPTION
Fixes issue #12 

There was a reported problem when authenticating on the gateway and the `next` param contained a query string, in which case the redirect location would drop said query string.

This changeset addresses 3 related issues:
- The `next` param is now fully url-encoded (both the path and the query string, if any).
- The query string component of the path, which was dropped in the middleware, is now maintained.
- The `resolve` function doesn't like query strings, so when we check that a url exists we temporarily drop the query string.
