### PR TITLE
Enable usage with Django 1.10's MIDDLEWARE setting

### DIFF
--- a/test_app/settings.py
+++ b/test_app/settings.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 """Test app settings."""
+from distutils.version import StrictVersion
 from os import path
+
+import django
+
+DJANGO_VERSION = StrictVersion(django.get_version())
 
 # set the django DEBUG option
 DEBUG = True
@@ -34,8 +39,7 @@ INSTALLED_APPS = (
     'test_app',
 )
 
-# none required, but need to explicitly state this for Django 1.7
-MIDDLEWARE_CLASSES = [
+ACTUAL_MIDDLEWARE_CLASSES = [
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -43,6 +47,11 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'perimeter.middleware.PerimeterAccessMiddleware',
 ]
+
+if DJANGO_VERSION < StrictVersion('1.10.0'):
+    MIDDLEWARE_CLASSES = ACTUAL_MIDDLEWARE_CLASSES
+else:
+    MIDDLEWARE = ACTUAL_MIDDLEWARE_CLASSES
 
 SECRET_KEY = "something really, really hard to guess goes here."
 

--- a/tox.ini
+++ b/tox.ini
@@ -34,5 +34,5 @@ deps =
 basepython =
     python2.7
 deps =
-    Django==1.10
+    Django==1.10.5
     coverage==3.7.1


### PR DESCRIPTION
While the package was tested under 1.10, it was not tested using the new MIDDLEWARE setting but instead the old MIDDLEWARE_CLASSES setting.

This commit:

a) forces us to use the MIDDLEWARE setting during testing under Django 1.10 and above.

b) utilises Django's MiddlewareMixin so that our Middleware can perform across versions.

c) updates our MiddlewareMixin constructor so that it can take the new Django supplied arguments in Django 1.10 and above.

Down the line, when MIDDLEWARE_CLASSES is official deprecated we will have to migrate our middleware to the new format. Until then, this will have to be our solution if we are to support old versions.