### PR TITLE
Restore middleware.set_request_token

### DIFF
--- a/perimeter/middleware.py
+++ b/perimeter/middleware.py
@@ -4,18 +4,32 @@ valid token. See Perimeter docs for more details.
 """
 from urllib.parse import urlencode
 
-from django.core.exceptions import MiddlewareNotUsed, ImproperlyConfigured
+from django.core.exceptions import ImproperlyConfigured, MiddlewareNotUsed
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.deprecation import MiddlewareMixin
 
 from .models import AccessToken
-from .settings import (
-    HTTP_X_PERIMETER_TOKEN,
-    PERIMETER_SESSION_KEY,
-    PERIMETER_ENABLED,
-    PERIMETER_BYPASS_FUNCTION as bypass_perimeter,
-)
+from .settings import PERIMETER_BYPASS_FUNCTION as bypass_perimeter
+from .settings import PERIMETER_ENABLED
+from .settings import HTTP_X_PERIMETER_TOKEN, PERIMETER_SESSION_KEY
+
+
+def get_request_token(request):
+    """Extract token string from HTTP header or querystring."""
+    return request.META.get(HTTP_X_PERIMETER_TOKEN, None) or request.session.get(
+        PERIMETER_SESSION_KEY, None
+    )
+
+
+def set_request_token(request, token_value):
+    """Sets the request.session token value.
+
+    Args:
+        token - string, the token value (not the token object, as that is
+            not serializable)
+    """
+    request.session[PERIMETER_SESSION_KEY] = token_value
 
 
 def check_middleware(request):
@@ -25,22 +39,6 @@ def check_middleware(request):
             "Missing session attribute - please check MIDDLEWARE_CLASSES for "
             "'django.contrib.sessions.middleware.SessionMiddleware'."
         )
-
-
-def get_request_token(request):
-    """Extract token string from HTTP header or querystring."""
-    check_middleware(request)
-    return request.META.get(HTTP_X_PERIMETER_TOKEN, None) or request.session.get(
-        PERIMETER_SESSION_KEY, None
-    )
-
-
-def get_access_token(request):
-    """Returns AccessToken if found else EmptyToken."""
-    token = get_request_token(request)
-    # NB this method implements caching, so is more performant
-    # than the straight get() alternative
-    return AccessToken.objects.get_access_token(token)
 
 
 class PerimeterAccessMiddleware(MiddlewareMixin):
@@ -59,17 +57,25 @@ class PerimeterAccessMiddleware(MiddlewareMixin):
         is not True - this is used by Django framework to remove the middleware.
         """
         if PERIMETER_ENABLED is False:
-            raise MiddlewareNotUsed()
-        super(PerimeterAccessMiddleware, self).__init__(*args, **kwargs)
+            raise MiddlewareNotUsed("Perimeter disabled")
+        super().__init__(*args, **kwargs)
+
+    def access_token(self, request):
+        """Fetch the AccessToken from the request."""
+        token_value = get_request_token(request)
+        return AccessToken.objects.get_access_token(token_value)
 
     def process_request(self, request):
         """Check user session for token."""
+        check_middleware(request)
+
         if bypass_perimeter(request):
             return None
 
-        if get_access_token(request).is_valid:
+        if self.access_token(request).is_valid:
             return None
 
         # redirect to the gateway for validation,
         qstring = urlencode({"next": request.get_full_path()})
-        return HttpResponseRedirect(reverse("perimeter:gateway") + "?" + qstring)
+        url = reverse("perimeter:gateway")
+        return HttpResponseRedirect(f"{url}?{qstring}")

--- a/perimeter/models.py
+++ b/perimeter/models.py
@@ -52,6 +52,8 @@ class AccessTokenManager(models.Manager):
             token - string, the token value to look up.
 
         """
+        if not token_value:
+            return EmptyToken()
         cache_key = AccessToken.get_cache_key(token_value)
         token = cache.get(cache_key)
         if token is None:

--- a/perimeter/tests/test_middleware.py
+++ b/perimeter/tests/test_middleware.py
@@ -8,7 +8,6 @@ from django.urls import reverse, resolve
 from ..middleware import (
     PerimeterAccessMiddleware,
     bypass_perimeter,
-    get_access_token,
     get_request_token,
     HTTP_X_PERIMETER_TOKEN,
     PERIMETER_SESSION_KEY,
@@ -58,14 +57,14 @@ class PerimeterMiddlewareTests(TestCase):
     def test_get_access_token(self):
         at = AccessToken.objects.create_access_token()
         self.request.session[PERIMETER_SESSION_KEY] = at.token
-        self.assertEqual(get_access_token(self.request), at)
+        self.assertEqual(self.middleware.get_access_token(self.request), at)
 
     def test_get_request_token_empty(self):
         token = get_request_token(self.request)
         self.assertIsNone(token)
 
     def test_get_access_token_empty(self):
-        token = get_access_token(self.request)
+        token = self.middleware.get_access_token(self.request)
         self.assertIsInstance(token, EmptyToken)
 
     def test_missing_session(self):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ chdir(path.normpath(path.join(path.abspath(__file__), pardir)))
 
 setup(
     name="django-perimeter",
-    version="0.12",
+    version="0.12.1",
     packages=find_packages(),
     include_package_data=True,
     license="MIT",

--- a/tox.ini
+++ b/tox.ini
@@ -11,5 +11,5 @@ deps =
 
 commands=
     coverage erase
-    coverage run --include=perimeter/* runtests.py
+    coverage run --source=perimeter --omit=*/migrations/*,*/tests/* runtests.py
     coverage report -m


### PR DESCRIPTION
Previous commit removed this function from `middleware`.
