### PR TITLE
Add chrome extension to add the X-Perimeter-Token

### DIFF
--- a/perimeter-bypass/README.md
+++ b/perimeter-bypass/README.md
@@ -1,0 +1,3 @@
+# Perimeter Bypass Chrome Extension
+
+This folder contains a Chrome extension that can be used to store perimeter tokens locally in the browser, applying the `X-Perimeter-Token` HTTP header to requests.

--- a/perimeter-bypass/background.js
+++ b/perimeter-bypass/background.js
@@ -1,0 +1,19 @@
+"use strict";
+
+// TODO: read in from options / storage
+const SITE1 = { url: "https://*/*", token: "foo" };
+
+// Simple extension to add "X-Perimeter-Token" to requests..
+chrome.webRequest.onBeforeSendHeaders.addListener(
+  function(details) {
+    details.requestHeaders.push({
+      name: "X-Perimeter-Token",
+      value: SITE1.token
+    });
+    return { requestHeaders: details.requestHeaders };
+  },
+  // filters
+  { urls: [SITE1.url] },
+  // extraInfoSpec
+  ["blocking", "requestHeaders"]
+);

--- a/perimeter-bypass/manifest.json
+++ b/perimeter-bypass/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "Django Perimeter Bypass",
+  "version": "1.0",
+  "description": "Chrome extension to add X-Perimeter-Token header.",
+  "manifest_version": 2,
+  "permissions": ["webRequest", "webRequestBlocking", "storage", "https://*/*"],
+  "background": {
+    "scripts": ["background.js"]
+  },
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
+  }
+}

--- a/perimeter-bypass/options.html
+++ b/perimeter-bypass/options.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Perimeter Bypass Settings</title>
+  </head>
+  <body>
+    <h1>Stored Perimeter Tokens</h1>
+    <fieldset>
+      <legend>Site Perimeter Tokens</legend>
+      <ol>
+        <li>
+          <label for="site1">Site URL</label>
+          <input type="text" id="site1" name="site1" value="" />
+          <label for="site1">Token</label>
+          <input type="password" id="token1" name="token1" value="" />
+        </li>
+      </ol>
+    </fieldset>
+
+    <div id="status"></div>
+    <button id="save">Save</button>
+
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/perimeter-bypass/options.js
+++ b/perimeter-bypass/options.js
@@ -1,0 +1,32 @@
+// TODO: improve UI, support more than one token
+
+// Saves options to chrome.storage
+function save_options() {
+  var url1 = document.getElementById("site1").value;
+  var token1 = document.getElementById("token1").value;
+  chrome.storage.sync.set(
+    {
+      site1: { url: url1, token: token1 }
+    },
+    function() {
+      // Update status to let user know options were saved.
+      var status = document.getElementById("status");
+      status.textContent = "Options saved.";
+      setTimeout(function() {
+        status.textContent = "";
+      }, 750);
+    }
+  );
+}
+
+// Restores select box and checkbox state using the preferences
+// stored in chrome.storage.
+function restore_options() {
+  // Use default value color = 'red' and likesColor = true.
+  chrome.storage.sync.get(["site1"], function(items) {
+    document.getElementById("site1").value = items.site1.url;
+    document.getElementById("token1").value = items.site1.token;
+  });
+}
+document.addEventListener("DOMContentLoaded", restore_options);
+document.getElementById("save").addEventListener("click", save_options);


### PR DESCRIPTION
Allows testers to bypass the perimeter.

Needs lots of work - this is not my forte. The goal is to allow users to store the token so that once they are set up they don't need to continue adding it manually to the site they are testing.
