### PR TITLE
Misc: Django 5.2 compatibility upgrade

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -61,23 +61,25 @@ jobs:
     strategy:
       matrix:
         python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        # build LTS version, next version, HEAD
-        django: ["32", "42", "50", "main"]
+        # build LTS version, current versions, HEAD
+        django: ["42", "50", "52", "main"]
         exclude:
           - python: "3.8"
             django: "50"
           - python: "3.8"
+            django: "52"
+          - python: "3.8"
             django: "main"
           - python: "3.9"
             django: "50"
+          - python: "3.9"
+            django: "52"
           - python: "3.9"
             django: "main"
           - python: "3.10"
             django: "main"
           - python: "3.11"
-            django: "32"
-          - python: "3.12"
-            django: "32"
+            django: "main"
 
     env:
       TOXENV: django${{ matrix.django }}-py${{ matrix.python }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
 
       # python code linting
       - id: ruff
-        entry: poetry run ruff --fix perimeter
+        entry: poetry run ruff check --fix
         language: system
         name: ruff      - Python code linting
         types: [python]

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.17.0
+
+- Adds support for Django 5.2
+- Drops support for Django versions below 4.2
+- Updates ruff command in pre-commit configuration
+
+No functional code changes.
+
 ## v0.16.0
 
 - Add support for Django 5.0

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ process that you have.
 
 ## Compatibility
 
-**This package now requires Python 3.8+ and Django 3.2+.**
+**This package now requires Python 3.8+ and Django 4.2+.**
 
 For previous versions please refer to the relevant branch.
 

--- a/perimeter/middleware.py
+++ b/perimeter/middleware.py
@@ -4,6 +4,7 @@ Check all incoming requests for a valid token.
 See Perimeter docs for more details.
 
 """
+
 from typing import Any, Callable, Optional, Union
 from urllib.parse import urlencode
 
@@ -24,7 +25,6 @@ from .settings import (
 def check_middleware(func: Callable) -> Callable:
     """Check a request arg has a Session attached."""
 
-    # noqa: blank line to make black and flake8 play nicely
     def inner(request: HttpRequest, *args: Any) -> Optional[HttpResponse]:
         if not hasattr(request, "session"):
             raise ImproperlyConfigured(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,16 +5,14 @@ description = "Site-wide perimeter access control for Django projects."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]
 maintainers = ["YunoJuno <code@yunojuno.com>"]
-readme = "README"
+readme = "README.md"
 homepage = "https://github.com/yunojuno/django-perimeter"
 repository = "https://github.com/yunojuno/django-perimeter"
 classifiers = [
     "Environment :: Web Environment",
-    "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4.0",
-    "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.2",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.8",
@@ -27,7 +25,7 @@ packages = [{ include = "perimeter" }]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-django = "^3.2 || ^4.0 | ^5.0"
+django = "^4.2 | ^5.0 | ^5.2"
 
 [tool.poetry.dev-dependencies]
 black = "*"

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,10 @@ envlist =
     fmt, lint, mypy,
     django-checks,
     ; https://docs.djangoproject.com/en/5.0/releases/
-    django32-py{38,39,310}
-    django40-py{38,39,310}
-    django41-py{38,39,310,311}
     django42-py{38,39,310,311}
     django50-py{310,311,312}
-    djangomain-py{311,312}
+    django52-py{310,311,312}
+    djangomain-py312
 
 [testenv]
 deps =
@@ -17,11 +15,9 @@ deps =
     pytest
     pytest-cov
     pytest-django
-    django32: Django>=3.2,<3.3
-    django40: Django>=4.0,<4.1
-    django41: Django>=4.1,<4.2
     django42: Django>=4.2,<4.3
     django50: https://github.com/django/django/archive/stable/5.0.x.tar.gz
+    django52: https://github.com/django/django/archive/stable/5.2.x.tar.gz
     djangomain: https://github.com/django/django/archive/main.tar.gz
 
 commands =
@@ -48,7 +44,7 @@ deps =
     ruff
 
 commands =
-    ruff perimeter
+    ruff check perimeter
 
 [testenv:mypy]
 description = Python source code type hints (mypy)


### PR DESCRIPTION
# Summary

This PR adds Django 5.2 compatibility and drops support for Django < 4.2.

## Why is this change being made?

To unblock the path to Django 5.2. 

## What changes does it include?

1. Adds support for Django 5.2
2. Removes support for Django versions below 4.2
3. Updates tox config to test Django 4.2, 5.0, 5.2 and main
4. Updates `ruff` command in pre-commit config to use modern syntax
5. Updates `README` and `CHANGELOG` documentation
6. No functional code changes.