### PR TITLE
Misc: Add styling to management commands output

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -64,7 +64,7 @@ jobs:
         django: ["52", "60", "main"]
 
     env:
-      TOXENV: django${{ matrix.django }}-py${{ matrix.python }}
+      TOXENV: django${{ matrix.django }}-py${{ matrix.python == '3.12' && '312' || '313' }}
 
     steps:
       - name: Check out the repository

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -63,9 +63,6 @@ jobs:
         python: ["3.12", "3.13"]
         django: ["52", "60", "main"]
 
-    env:
-      TOXENV: django${{ matrix.django }}-py${{ matrix.python == '3.12' && '312' || '313' }}
-
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4
@@ -78,4 +75,4 @@ jobs:
       - name: Install and run tox
         run: |
           pip install tox
-          tox
+          TOXENV=django${{ matrix.django }}-py$(echo ${{ matrix.python }} | tr -d '.') tox

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 default_stages: [commit]
 
 default_language_version:
-  python: python3.11
+  python: python3.13
 
 repos:
   # Note that all of the `local` repo hooks are version managed by

--- a/perimeter/management/commands/create_access_token.py
+++ b/perimeter/management/commands/create_access_token.py
@@ -42,18 +42,24 @@ class Command(BaseCommand):
                 token=token, expires_on=expires_on
             )
             self.stdout.write(
-                'Created new access token: "{}" (expires {})'.format(
-                    access_token.token, access_token.expires_on
+                self.style.SUCCESS(
+                    'Created new access token: "{}" (expires {})'.format(
+                        access_token.token, access_token.expires_on
+                    )
                 )
             )
         except IntegrityError:
             access_token = AccessToken.objects.get(token=token)
             if has_expires:
-                self.stdout.write("Extending existing token")
+                self.stdout.write(self.style.NOTICE("Extending existing token"))
                 access_token.expires_on = expires_on
                 access_token.save()
-                self.stdout.write("Token extended: {}".format(access_token))
+                self.stdout.write(
+                    self.style.SUCCESS("Token extended: {}".format(access_token))
+                )
             else:
                 self.stdout.write(
-                    "Token exists already - please use --expires option to extend."
+                    self.style.WARNING(
+                        "Token exists already - please use --expires option to extend."
+                    )
                 )

--- a/perimeter/management/commands/create_access_token.py
+++ b/perimeter/management/commands/create_access_token.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Management command to create a new AccessToken."""
+
 import datetime
 from argparse import ArgumentParser
 from typing import Any

--- a/perimeter/management/commands/list_access_tokens.py
+++ b/perimeter/management/commands/list_access_tokens.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Management command to list all active tokens."""
+
 from typing import Any
 
 from django.core.management.base import BaseCommand

--- a/perimeter/management/commands/list_access_tokens.py
+++ b/perimeter/management/commands/list_access_tokens.py
@@ -15,4 +15,8 @@ class Command(BaseCommand):
         for token in AccessToken.objects.all():
             prefix = "- " if token.is_valid else "x "
             suffix = " expired " if token.has_expired else " expires "
-            self.stdout.write(f"{prefix} {token} {suffix} {token.expires_on}")
+            line = f"{prefix}{token} {suffix} {token.expires_on}"
+            if token.is_valid:
+                self.stdout.write(self.style.SUCCESS(line))
+            else:
+                self.stdout.write(self.style.ERROR(line))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-perimeter"
-version = "0.18.0"
+version = "0.18.1"
 description = "Site-wide perimeter access control for Django projects."
 license = "MIT"
 authors = ["YunoJuno <code@yunojuno.com>"]


### PR DESCRIPTION
Add styling to management commands output

- create_access_token: GREEN for success, YELLOW for notices, RED for warnings
- list_access_tokens: GREEN for valid tokens, RED for expired
- Fix double-space bug in list output